### PR TITLE
feat: update user serializer to include additional user details

### DIFF
--- a/Backend/listings/serializers.py
+++ b/Backend/listings/serializers.py
@@ -6,8 +6,10 @@ from django.utils import timezone
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ["id", "username", "email", "password", "phone_number"]
-        extra_kwargs = {"password": {"write_only": True}}
+        fields = ["id", "username", "first_name", "last_name", "email", "phone_number"]
+        extra_kwargs = { 
+            "id": {"read_only": True}
+        }
 
     def create(self, validated_data):
         return User.objects.create(**validated_data)


### PR DESCRIPTION
- Modified the user serializer to return more user-related data.
- Previously, only limited fields were exposed; now includes email, phone number, first name, last name, phone number.
- Ensured sensitive data (e.g., password) is still excluded.